### PR TITLE
Update README.md to explain that appender creation will fail unless t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if err != {
 }
 defer conn.Close()
 
-// Retrieve appender from connection.
+// Retrieve appender from connection (note that you have to create the table 'test' beforehand)
 appender, err := NewAppenderFromConn(conn, "", "test")
 if err != {
   ...


### PR DESCRIPTION
…he table mentioned will already be created

Update README.md to explain that appender creation will fail unless the table mentioned will already be created